### PR TITLE
fix: run generated test through temporary file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+.vim
+.idea
 node_modules
 logs
 tests_output
+
+# Debug config for Vimspector (Vim/Neovim)
+.vimspector.json
+
+# Vim's swap files
+*.swp
+*.swo

--- a/src/tmp_file.js
+++ b/src/tmp_file.js
@@ -1,0 +1,32 @@
+const fs = require("fs");
+
+const TMP_TEST_FILE = "_tmp_test_file.js";
+
+/**
+ * Flushes the content to the FS as the virtual test.
+ *
+ * @param {string} content
+ * @returns {Promise<void>}
+ */
+const write = (content) =>
+  fs.promises.writeFile(TMP_TEST_FILE, content, {
+    encoding: "utf8",
+  });
+
+/**
+ * Removes the virtual test file from the FS.
+ *
+ * @returns {Promise<void>}
+ */
+const clean = () =>
+  fs.promises.unlink(TMP_TEST_FILE).catch((error) => {
+    if (error.code === "ENOENT") {
+      // The file doesn't exist and it is okay. Just do nothing.
+    } else {
+      throw error;
+    }
+  });
+
+exports.TMP_TEST_NAME = TMP_TEST_FILE;
+exports.writeTmpTestFile = write;
+exports.removeTmpTestFile = clean;


### PR DESCRIPTION
  Vite cannot bundle the JS between the <script> tags. And if that code contains imports, each of them Vite bundles independently  (at least, it seems like it). And for example, when we want to test a React component, then the inline script will contain references to "react" and "react-dom" packages to be able to render a component,  but the component file will likely contain another reference to the  "react". That means that Vite ends up bundling two different versions of React, which will conflict.
