### PR TITLE
fix: do not hardcode paths to node_modules

### DIFF
--- a/nightwatch/commands/mountReactComponent.js
+++ b/nightwatch/commands/mountReactComponent.js
@@ -167,7 +167,7 @@ module.exports = class Command {
           done(browserResult);
         }, 100);
       }, [Command.rootElementId]);
-   
+
     if (!result || !result.element || preRenderError || postRenderError) {
       const err = this.getError('Could not mount the component.');
       if (preRenderError) {
@@ -200,12 +200,10 @@ module.exports = class Command {
   }
 
   static _getReactImports() {
-    const {version} = require(path.resolve('node_modules', 'react'));
-    const reactDOMSuffix = version.startsWith('18') ? '/client': '';
 
     return `
       import * as React from 'react';
-      import * as ReactDOM from "react-dom${reactDOMSuffix}";
+      import * as ReactDOM from "react-dom/client";
     `;
   }
 
@@ -265,7 +263,7 @@ module.exports = class Command {
       return '';
     }
 
-    return 'import "/node_modules/vite-plugin-nightwatch/nightwatch/describe.js";';
+    return 'import "vite-plugin-nightwatch/nightwatch/describe.js";';
   }
 
   /**
@@ -284,11 +282,11 @@ module.exports = class Command {
 
     return `
 			const isComponentDefaultExported = typeof _csfDescription === 'undefined';
-			
+
 			const commonArgs = isComponentDefaultExported ? {} : (_csfDescription.args || {});
 			const componentArgs = Component.args || {};
       const inlineProps = ${propsToInsert} || {};
-      
+
       const props = { ...commonArgs, ...componentArgs, ...inlineProps };
 		`;
   }
@@ -300,26 +298,26 @@ module.exports = class Command {
 
       ${Command._getReactImports()}
       ${Command._addDescribeMocks(isJSX)}
-      
+
       ${Command._createComponentImport(Component)}
       ${Command._createIndexImport()}
-           
+
       ${Command._unifyReactDOM()}
       ${Command._createProps(props)}
-      
+
       const element = React.createElement(Component, props);
       const canvasElement = document.getElementById('${Command.rootElementId}');
       renderReactElement(element, canvasElement);
-      
+
       window.__nightwatch = {};
-       
+
       window['@component_class'] = Component;
       window['@component_element'] = element;
       window['@@component_props'] = props;
       window['@@canvas_element'] = canvasElement;
       window['@@playfn_result'] = null;
       window.__$$PlayFnError = null;
-      window.__$$PlayFnDone = false;         
+      window.__$$PlayFnDone = false;
     `;
   }
 

--- a/nightwatch/commands/mountReactComponent.js
+++ b/nightwatch/commands/mountReactComponent.js
@@ -263,7 +263,7 @@ module.exports = class Command {
       return '';
     }
 
-    return 'import "vite-plugin-nightwatch/nightwatch/describe.js";';
+    return 'import "vite-plugin-nightwatch-fixes/nightwatch/describe.js";';
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-nightwatch-fixes",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-nightwatch-fixes",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "MIT",
       "dependencies": {
         "@nightwatch/esbuild-utils": "0.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vite-plugin-nightwatch",
+  "name": "vite-plugin-nightwatch-fixes",
   "version": "0.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite-plugin-nightwatch",
+      "name": "vite-plugin-nightwatch-fixes",
       "version": "0.4.6",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-nightwatch-fixes",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Component testing plugin that integrates Vite with Nightwatch.js. Supports Vue and React components with more to come soon.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite-plugin-nightwatch",
+  "name": "vite-plugin-nightwatch-fixes",
   "version": "0.4.6",
   "description": "Component testing plugin that integrates Vite with Nightwatch.js. Supports Vue and React components with more to come soon.",
   "main": "index.js",

--- a/src/utils/injectScript.js
+++ b/src/utils/injectScript.js
@@ -1,25 +1,25 @@
 const reactScript = (path) =>
   `
-		import '/node_modules/react/umd/react.development.js';
-		import '/node_modules/react-dom/umd/react-dom.development.js';
-      
+		import 'react/umd/react.development.js';
+		import 'react-dom/umd/react-dom.development.js';
+
 		import Component from '${path}';
-		
+
 		const renderReactElement = 'createRoot' in ReactDOM
 			? (element, container) =>
 					ReactDOM
 						.createRoot(container)
 						.render(element)
 			: ReactDOM.render;
-			
+
 		const props = Component.args || {};
-		
+
 		const element = React.createElement(Component, props);
-		
+
 		const canvasElement = document.getElementById('app');
-		
+
 		renderReactElement(element, canvasElement);
-		
+
 		window['@component_class'] = Component;
     window['@component_element'] = element;
 	`;
@@ -28,12 +28,12 @@ const vueScript = (path) =>
   `
 		import {mount} from '/node_modules/@vue/test-utils/dist/vue-test-utils.esm-browser.js';
 		import Component from '${path}';
-		
+
 		const element = mount(Component, {
 		 attachTo: document.getElementById('app'),
 		 global: {}
 		});
-		
+
 		window['@component_element'] = element;
 		window['@component_class'] = Component;
 	`;

--- a/test/unit/testPlugin.js
+++ b/test/unit/testPlugin.js
@@ -5,7 +5,7 @@ describe('Vite Nightwatch plugin basic tests', function() {
 
   it('test plugin config with defaults', function(done) {
     fs.readFile = (filename, encoding, callback) => {
-      assert.ok(filename.endsWith('vite-plugin-nightwatch/src/renderer.html'));
+      assert.ok(filename.endsWith('vite-plugin-nightwatch-fixes/src/renderer.html'));
       callback(null, '');
     };
 
@@ -39,7 +39,7 @@ describe('Vite Nightwatch plugin basic tests', function() {
 
   it('test plugin config with componentType=react', function(done) {
     fs.readFile = (filename, encoding, callback) => {
-      assert.ok(filename.endsWith('vite-plugin-nightwatch/src/renderer.html'));
+      assert.ok(filename.endsWith('vite-plugin-nightwatch-fixes/src/renderer.html'));
       callback(null, '');
     };
 


### PR DESCRIPTION
In the context of a monorepo, this plugin is unusable because the path for node_modules is hard-coded. This resolves that issue. 

React 18 came out 3 years ago...I think it's ok to let go of React 17 or earlier as well.